### PR TITLE
cluster: guard 0-tab Safari windows (#85 #86 #87)

### DIFF
--- a/Sources/SafariBrowser/Daemon/PreCompiledScripts.swift
+++ b/Sources/SafariBrowser/Daemon/PreCompiledScripts.swift
@@ -108,8 +108,15 @@ enum PreCompiledScripts {
             // AppleScript string literal. The caller is responsible for
             // escaping embedded quotes / backslashes before rendering —
             // see `String.escapedForAppleScript` in `SafariBridge.swift`.
+            //
+            // #87: a 0-tab front window has no `current tab`; the bare
+            // `do JavaScript ... in current tab of front window` would raise
+            // a raw -1728. Guard with an explicit, actionable error first.
             source: """
                 tell application "Safari"
+                    if (count of tabs of front window) = 0 then
+                        error "front window has no tabs — open a tab or target a specific window/url"
+                    end if
                     do JavaScript "{{JS_SOURCE}}" in current tab of front window
                 end tell
                 """

--- a/Sources/SafariBrowser/Daemon/PreCompiledScripts.swift
+++ b/Sources/SafariBrowser/Daemon/PreCompiledScripts.swift
@@ -112,8 +112,14 @@ enum PreCompiledScripts {
             // #87: a 0-tab front window has no `current tab`; the bare
             // `do JavaScript ... in current tab of front window` would raise
             // a raw -1728. Guard with an explicit, actionable error first.
+            // The zero-windows guard MUST come first — with no windows,
+            // `front window` itself doesn't exist, so `count of tabs of
+            // front window` would raise the same raw -1728 (#88 verify M1).
             source: """
                 tell application "Safari"
+                    if (count of windows) = 0 then
+                        error "Safari has no windows — open a window or target a specific window/url"
+                    end if
                     if (count of tabs of front window) = 0 then
                         error "front window has no tabs — open a tab or target a specific window/url"
                     end if

--- a/Sources/SafariBrowser/SafariBridge.swift
+++ b/Sources/SafariBrowser/SafariBridge.swift
@@ -2024,19 +2024,27 @@ enum SafariBridge {
     /// Performance: O(1) AppleScript roundtrips regardless of window /
     /// tab count, vs. the naive per-tab query approach which would
     /// dominate upload latency (10 windows × 5 tabs ≈ 70 roundtrips).
-    static func listAllWindows() async throws -> [WindowInfo] {
-        let script = """
-            tell application "Safari"
-                set windowCount to count of windows
-                if windowCount = 0 then
-                    return ""
-                end if
-                set output to ""
-                set GS to (character id 29)
-                set RS to (character id 30)
-                repeat with w from 1 to windowCount
+    /// AppleScript that enumerates every window/tab in one roundtrip.
+    /// Exposed for unit-testing the guard structure (ZeroTabWindowGuardTests);
+    /// the string is the pure testable output — live execution is E2E-only.
+    ///
+    /// #85: a window with 0 tabs has no `current tab`; reading it raises
+    /// AppleScript -1728. We count tabs FIRST and skip 0-tab windows entirely,
+    /// so one empty window (e.g. a freshly-opened profile window) can't blow up
+    /// the whole enumeration that every window-targeting command depends on.
+    static let listAllWindowsScript = """
+        tell application "Safari"
+            set windowCount to count of windows
+            if windowCount = 0 then
+                return ""
+            end if
+            set output to ""
+            set GS to (character id 29)
+            set RS to (character id 30)
+            repeat with w from 1 to windowCount
+                set tabCount to count of tabs of window w
+                if tabCount > 0 then
                     set currentIdx to index of current tab of window w
-                    set tabCount to count of tabs of window w
                     -- Window-level title carries the profile prefix
                     -- (e.g. "個人 — Plaud Web") on Safari 17+ multi-profile
                     -- setups. Per-tab `name of tab` does NOT include the
@@ -2056,11 +2064,14 @@ enum SafariBridge {
                         end if
                         set output to output & w & GS & t & GS & isCur & GS & tabUrl & GS & tabName & GS & winName & RS
                     end repeat
-                end repeat
-                return output
-            end tell
-            """
-        let raw = try await runAppleScript(script)
+                end if
+            end repeat
+            return output
+        end tell
+        """
+
+    static func listAllWindows() async throws -> [WindowInfo] {
+        let raw = try await runAppleScript(listAllWindowsScript)
         return parseWindowEnumeration(raw)
     }
 

--- a/Sources/SafariBrowser/SafariBridge.swift
+++ b/Sources/SafariBrowser/SafariBridge.swift
@@ -2275,6 +2275,19 @@ enum SafariBridge {
     /// caps per-call AX messaging at 2 seconds (default is 6s). With
     /// up to ~10 AX calls per resolution, this bounds total hang at
     /// ~20s for pathological Safari states.
+    /// Tab-independent existence probe for window N. Exposed for unit testing
+    /// (ZeroTabWindowGuardTests). #86: the previous check read `current tab of
+    /// window N`, which raises -1728 for a window that exists but has 0 tabs —
+    /// a false negative. `id of window N` succeeds for any existing window
+    /// regardless of tab count.
+    static func windowExistenceValidationScript(windowIndex: Int) -> String {
+        """
+        tell application "Safari"
+            set _ to id of window \(windowIndex)
+        end tell
+        """
+    }
+
     private static func getWindowIDViaAX(windowIndex: Int) async throws -> (cgID: String, axWindow: AXUIElement?) {
         guard AXIsProcessTrusted() else {
             throw SafariBrowserError.accessibilityNotGranted
@@ -2282,11 +2295,11 @@ enum SafariBridge {
 
         // Validate window N exists. Routes through runTargetedAppleScript so
         // a bad `--window 99` surfaces `documentNotFound` with available-docs.
-        _ = try await runTargetedAppleScript("""
-            tell application "Safari"
-                set t to current tab of window \(windowIndex)
-            end tell
-            """, target: .windowIndex(windowIndex))
+        // #86: probe via `id of window N` (tab-independent) — the former
+        // `current tab of window N` raised -1728 for an existing 0-tab window.
+        _ = try await runTargetedAppleScript(
+            windowExistenceValidationScript(windowIndex: windowIndex),
+            target: .windowIndex(windowIndex))
 
         // Read bounds of window N (AS). Used to match against AX windows below.
         let asBoundsRaw = try await runAppleScript("""

--- a/Tests/SafariBrowserTests/ZeroTabWindowGuardTests.swift
+++ b/Tests/SafariBrowserTests/ZeroTabWindowGuardTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import SafariBrowser
+
+/// Regression guards for the "zero-tab Safari window" family (#85, #86, #87).
+///
+/// A Safari window with 0 tabs exists but has no `current tab`; AppleScript
+/// that reads `current tab` unconditionally raises `-1728`. These tests assert
+/// the guard *structure* in the pure AppleScript-string outputs — this repo
+/// tests AppleScript at the string level (see DocumentsCommandTests /
+/// PreCompiledScriptsTests); live 0-tab execution is covered by E2E, not here.
+final class ZeroTabWindowGuardTests: XCTestCase {
+
+    // MARK: - #85 listAllWindows enumeration
+
+    func testListAllWindowsScript_countsTabsBeforeReadingCurrentTab() {
+        let script = SafariBridge.listAllWindowsScript
+        guard let countRange = script.range(of: "count of tabs of window w"),
+              let currentRange = script.range(of: "current tab of window w") else {
+            return XCTFail("script missing expected tab / current-tab references")
+        }
+        XCTAssertLessThan(
+            countRange.lowerBound, currentRange.lowerBound,
+            "must count tabs BEFORE reading current tab so 0-tab windows are skipped (#85)")
+    }
+
+    func testListAllWindowsScript_guardsZeroTabWindows() {
+        let script = SafariBridge.listAllWindowsScript
+        XCTAssertTrue(
+            script.contains("if tabCount > 0"),
+            "0-tab windows must be skipped via a tabCount guard (#85)")
+    }
+
+    // MARK: - #86 getWindowIDViaAX existence validation
+
+    func testWindowExistenceValidation_doesNotReadCurrentTab() {
+        let script = SafariBridge.windowExistenceValidationScript(windowIndex: 3)
+        XCTAssertFalse(
+            script.contains("current tab"),
+            "window existence must not be proven via `current tab` — 0-tab windows exist but have none (#86)")
+    }
+
+    func testWindowExistenceValidation_usesTabIndependentProbe() {
+        let script = SafariBridge.windowExistenceValidationScript(windowIndex: 3)
+        XCTAssertTrue(
+            script.contains("id of window 3") || script.contains("exists window 3"),
+            "existence must use a tab-independent probe (id / exists) (#86)")
+    }
+
+    // MARK: - #87 daemon runJSInCurrentTab
+
+    func testRunJSInCurrentTabTemplate_guardsZeroTabFrontWindow() {
+        guard let tmpl = PreCompiledScripts.known["runJSInCurrentTab"] else {
+            return XCTFail("runJSInCurrentTab template missing")
+        }
+        XCTAssertTrue(
+            tmpl.source.contains("count of tabs of front window"),
+            "must guard a 0-tab front window before `do JavaScript in current tab` (#87)")
+    }
+}

--- a/Tests/SafariBrowserTests/ZeroTabWindowGuardTests.swift
+++ b/Tests/SafariBrowserTests/ZeroTabWindowGuardTests.swift
@@ -56,4 +56,44 @@ final class ZeroTabWindowGuardTests: XCTestCase {
             tmpl.source.contains("count of tabs of front window"),
             "must guard a 0-tab front window before `do JavaScript in current tab` (#87)")
     }
+
+    func testRunJSInCurrentTabTemplate_guardsZeroWindowsBeforeFrontWindow() {
+        // #88 verify M1: with 0 windows, `front window` doesn't exist, so the
+        // tab-count guard itself would raise -1728. The windows guard must run first.
+        guard let tmpl = PreCompiledScripts.known["runJSInCurrentTab"] else {
+            return XCTFail("runJSInCurrentTab template missing")
+        }
+        guard let winGuard = tmpl.source.range(of: "count of windows"),
+              let tabGuard = tmpl.source.range(of: "count of tabs of front window") else {
+            return XCTFail("template missing windows / front-window tab guards")
+        }
+        XCTAssertLessThan(
+            winGuard.lowerBound, tabGuard.lowerBound,
+            "zero-windows guard must precede the front-window tab-count guard (#87 / #88 M1)")
+    }
+
+    // MARK: - #88 verify L5/L11: tighten #85 ordering to pin current-tab INSIDE the guard
+
+    func testListAllWindowsScript_readsCurrentTabInsideTabCountGuard() {
+        // Stronger than countsTabsBeforeReadingCurrentTab: the guard keyword must
+        // appear BEFORE the current-tab read, proving current tab is read inside
+        // `if tabCount > 0` — not merely somewhere after `count of tabs`.
+        let script = SafariBridge.listAllWindowsScript
+        guard let guardRange = script.range(of: "if tabCount > 0"),
+              let currentRange = script.range(of: "current tab of window w") else {
+            return XCTFail("script missing guard / current-tab references")
+        }
+        XCTAssertLessThan(
+            guardRange.lowerBound, currentRange.lowerBound,
+            "current tab must be read INSIDE the `if tabCount > 0` guard (#85 / #88 L5)")
+    }
+
+    // MARK: - #88 verify L4/L7: behavior test for the empty-enumeration path
+
+    func testParseWindowEnumeration_emptyStringYieldsNoWindows() {
+        // When every window is 0-tab, listAllWindowsScript returns "" (same as
+        // 0 windows). Confirm the parser treats that as "no windows" cleanly,
+        // not a parse error — so documents/--url show "no documents" not garbage.
+        XCTAssertEqual(SafariBridge.parseWindowEnumeration(""), [])
+    }
 }

--- a/Tests/SafariBrowserTests/ZeroTabWindowGuardTests.swift
+++ b/Tests/SafariBrowserTests/ZeroTabWindowGuardTests.swift
@@ -8,7 +8,26 @@ import XCTest
 /// the guard *structure* in the pure AppleScript-string outputs — this repo
 /// tests AppleScript at the string level (see DocumentsCommandTests /
 /// PreCompiledScriptsTests); live 0-tab execution is covered by E2E, not here.
+///
+/// Assertion discipline (#88 re-verify): pin the guard *block* (condition +
+/// body), not merely textual precedence — a "keyword before read" check passes
+/// even when a refactor moves the read outside the guard's `end if`, or inverts
+/// the condition, or empties the body. Helpers below extract the guarded region.
 final class ZeroTabWindowGuardTests: XCTestCase {
+
+    /// The statements between an AppleScript guard keyword and its next `end if`.
+    private func guardBody(_ script: String, after keyword: String) -> Substring? {
+        guard let start = script.range(of: keyword),
+              let endIf = script.range(of: "end if", range: start.upperBound..<script.endIndex)
+        else { return nil }
+        return script[start.upperBound..<endIf.lowerBound]
+    }
+
+    /// The first non-whitespace content immediately after a keyword.
+    private func firstStatement(_ script: String, after keyword: String) -> Substring? {
+        guard let start = script.range(of: keyword) else { return nil }
+        return script[start.upperBound...].drop(while: { $0 == " " || $0 == "\n" || $0 == "\t" })
+    }
 
     // MARK: - #85 listAllWindows enumeration
 
@@ -24,76 +43,91 @@ final class ZeroTabWindowGuardTests: XCTestCase {
     }
 
     func testListAllWindowsScript_guardsZeroTabWindows() {
-        let script = SafariBridge.listAllWindowsScript
         XCTAssertTrue(
-            script.contains("if tabCount > 0"),
+            SafariBridge.listAllWindowsScript.contains("if tabCount > 0"),
             "0-tab windows must be skipped via a tabCount guard (#85)")
+    }
+
+    func testListAllWindowsScript_currentTabReadIsFirstStatementInsideGuard() {
+        // #88 re-verify L5/L7: prove the read is INSIDE the guard, not merely
+        // after the keyword. Moving `set currentIdx` past `end if` (still in the
+        // loop but outside the guard) reopens the -1728 crash — this must fail then.
+        guard let after = firstStatement(SafariBridge.listAllWindowsScript, after: "if tabCount > 0 then") else {
+            return XCTFail("script missing `if tabCount > 0 then` guard")
+        }
+        XCTAssertTrue(
+            after.hasPrefix("set currentIdx to index of current tab of window w"),
+            "current-tab read must be the FIRST statement inside the `if tabCount > 0` guard (#85)")
     }
 
     // MARK: - #86 getWindowIDViaAX existence validation
 
     func testWindowExistenceValidation_doesNotReadCurrentTab() {
-        let script = SafariBridge.windowExistenceValidationScript(windowIndex: 3)
         XCTAssertFalse(
-            script.contains("current tab"),
+            SafariBridge.windowExistenceValidationScript(windowIndex: 3).contains("current tab"),
             "window existence must not be proven via `current tab` — 0-tab windows exist but have none (#86)")
     }
 
-    func testWindowExistenceValidation_usesTabIndependentProbe() {
-        let script = SafariBridge.windowExistenceValidationScript(windowIndex: 3)
+    func testWindowExistenceValidation_usesThrowingIdProbe() {
+        // #88 re-verify L4: pin the throwing `id of window N` probe. A bare
+        // `exists window N` fails OPEN (returns false, doesn't throw) unless
+        // wrapped as `if not (exists ...) then error`, so don't accept it here.
         XCTAssertTrue(
-            script.contains("id of window 3") || script.contains("exists window 3"),
-            "existence must use a tab-independent probe (id / exists) (#86)")
+            SafariBridge.windowExistenceValidationScript(windowIndex: 3).contains("id of window 3"),
+            "existence must use the throwing `id of window N` probe, not a fail-open bare `exists` (#86)")
     }
 
     // MARK: - #87 daemon runJSInCurrentTab
 
-    func testRunJSInCurrentTabTemplate_guardsZeroTabFrontWindow() {
+    func testRunJSInCurrentTabTemplate_zeroTabGuardErrorsBeforeDoJavaScript() {
+        // #88 re-verify (finding 2): the 0-tab front-window guard must error with
+        // an explicit message AND precede the do-JavaScript line.
         guard let tmpl = PreCompiledScripts.known["runJSInCurrentTab"] else {
             return XCTFail("runJSInCurrentTab template missing")
+        }
+        let s = tmpl.source
+        guard let body = guardBody(s, after: "count of tabs of front window") else {
+            return XCTFail("front-window tab guard missing or unclosed")
         }
         XCTAssertTrue(
-            tmpl.source.contains("count of tabs of front window"),
-            "must guard a 0-tab front window before `do JavaScript in current tab` (#87)")
+            body.contains("error") && body.contains("front window has no tabs"),
+            "0-tab front-window guard must error with an explicit message (#87)")
+        guard let tabGuard = s.range(of: "count of tabs of front window"),
+              let doJS = s.range(of: "do JavaScript") else {
+            return XCTFail("template missing tab guard / do JavaScript")
+        }
+        XCTAssertLessThan(
+            tabGuard.lowerBound, doJS.lowerBound,
+            "tab guard must precede `do JavaScript` (#87)")
     }
 
-    func testRunJSInCurrentTabTemplate_guardsZeroWindowsBeforeFrontWindow() {
-        // #88 verify M1: with 0 windows, `front window` doesn't exist, so the
-        // tab-count guard itself would raise -1728. The windows guard must run first.
+    func testRunJSInCurrentTabTemplate_zeroWindowsGuardErrorsAndOrdersFirst() {
+        // #88 re-verify M1 / finding 6: pin the `= 0` condition + error body, not
+        // just ordering. Inverting `= 0`→`> 0` or emptying the guard must fail here.
         guard let tmpl = PreCompiledScripts.known["runJSInCurrentTab"] else {
             return XCTFail("runJSInCurrentTab template missing")
         }
-        guard let winGuard = tmpl.source.range(of: "count of windows"),
-              let tabGuard = tmpl.source.range(of: "count of tabs of front window") else {
-            return XCTFail("template missing windows / front-window tab guards")
+        let s = tmpl.source
+        guard let body = guardBody(s, after: "if (count of windows) = 0 then") else {
+            return XCTFail("zero-windows `= 0` guard missing or unclosed (#87 M1)")
+        }
+        XCTAssertTrue(
+            body.contains("error") && body.contains("Safari has no windows"),
+            "zero-windows guard must error with an explicit message — an empty guard reopens -1728 (#87 M1)")
+        guard let winGuard = s.range(of: "if (count of windows) = 0 then"),
+              let tabGuard = s.range(of: "count of tabs of front window") else {
+            return XCTFail("template missing windows / tab guards")
         }
         XCTAssertLessThan(
             winGuard.lowerBound, tabGuard.lowerBound,
-            "zero-windows guard must precede the front-window tab-count guard (#87 / #88 M1)")
+            "zero-windows guard must precede the front-window tab-count guard (#87 M1)")
     }
 
-    // MARK: - #88 verify L5/L11: tighten #85 ordering to pin current-tab INSIDE the guard
-
-    func testListAllWindowsScript_readsCurrentTabInsideTabCountGuard() {
-        // Stronger than countsTabsBeforeReadingCurrentTab: the guard keyword must
-        // appear BEFORE the current-tab read, proving current tab is read inside
-        // `if tabCount > 0` — not merely somewhere after `count of tabs`.
-        let script = SafariBridge.listAllWindowsScript
-        guard let guardRange = script.range(of: "if tabCount > 0"),
-              let currentRange = script.range(of: "current tab of window w") else {
-            return XCTFail("script missing guard / current-tab references")
-        }
-        XCTAssertLessThan(
-            guardRange.lowerBound, currentRange.lowerBound,
-            "current tab must be read INSIDE the `if tabCount > 0` guard (#85 / #88 L5)")
-    }
-
-    // MARK: - #88 verify L4/L7: behavior test for the empty-enumeration path
+    // MARK: - Parser behavior
 
     func testParseWindowEnumeration_emptyStringYieldsNoWindows() {
         // When every window is 0-tab, listAllWindowsScript returns "" (same as
-        // 0 windows). Confirm the parser treats that as "no windows" cleanly,
-        // not a parse error — so documents/--url show "no documents" not garbage.
+        // 0 windows). The parser must treat that as "no windows" cleanly.
         XCTAssertEqual(SafariBridge.parseWindowEnumeration(""), [])
     }
 }


### PR DESCRIPTION
Refs #85 Refs #86 Refs #87

## Summary
Three same-root fixes for the "0-tab Safari window" family. `current tab` was used as a proxy for "window has content / window exists", but a 0-tab window breaks that assumption — it exists yet has no `current tab`, so reading it raises AppleScript `-1728`.

- **#85** `listAllWindows` enumeration — count tabs *before* reading `current tab`; skip 0-tab windows. Fixes every window-enumerating command (`documents`, `--url` resolution, …) dying when any single 0-tab window exists (the high-impact one — a shared function that all target resolution flows through).
- **#86** `getWindowIDViaAX` — window existence probed via tab-independent `id of window N`, not `current tab of window N` (fixes `--window N` on an existing 0-tab window for AX-path commands like screenshot/pdf).
- **#87** daemon `runJSInCurrentTab` — explicit actionable error for a 0-tab front window instead of a raw `-1728`.

## Tests
- New `ZeroTabWindowGuardTests` — string-assertion guards for the three AppleScript outputs (this repo's pattern for AppleScript; live 0-tab behavior is E2E-only, documented in the test header).
- Full suite green, no regression.

## Checklist
- [x] Diagnose (#85 root cause; #86 / #87 verified sister concerns)
- [x] Implement (4 commits)
- [ ] Verify (run `/idd-verify #85 #86 #87`)
- [x] Verify-gated: after merge, `/idd-close` per issue (manual gate + closing summary; no auto-close trailer)

---
Generated by /idd-implement (cluster PR path). **Do NOT add a GitHub close trailer** — IDD discipline requires manual /idd-close after merge.
